### PR TITLE
Add the thin_provision parameter to infini_fs

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "infinidat"
 name: "infinibox"
-version: "1.2.3"
+version: "1.2.4"
 readme: "README.md"
 authors:
   - "Infinidat <partners.infi@infinidat.com>"

--- a/playbooks/test_create_resources.yml
+++ b/playbooks/test_create_resources.yml
@@ -44,6 +44,17 @@
       password: "{{ password }}"
       system: "{{ system }}"
 
+  - name: POSITIVE test -> Create THIN file system named {{ auto_prefix }}fs_thin under pool {{ auto_prefix }}pool
+    infini_fs:
+      name: "{{ auto_prefix }}fs_thin"
+      size: 1GB
+      pool: "{{ auto_prefix }}pool"
+      thin_provision: true
+      state: present
+      user: "{{ user }}"
+      password: "{{ password }}"
+      system: "{{ system }}"
+
   - name: POSITIVE test -> Stat file system named {{ auto_prefix }}fs under pool {{ auto_prefix }}pool
     infini_fs:
       name: "{{ auto_prefix }}fs"

--- a/plugins/module_utils/infinibox.py
+++ b/plugins/module_utils/infinibox.py
@@ -70,11 +70,14 @@ def get_system(module):
     password = module.params.get('password', None)
 
     if user and password:
-        system = InfiniBox(box, auth=(user, password))
+        system = InfiniBox(box, auth=(user, password), use_ssl=True)
     elif environ.get('INFINIBOX_USER') and environ.get('INFINIBOX_PASSWORD'):
-        system = InfiniBox(box, auth=(environ.get('INFINIBOX_USER'), environ.get('INFINIBOX_PASSWORD')))
+        system = InfiniBox(box, \
+                           auth=(environ.get('INFINIBOX_USER'), \
+                                 environ.get('INFINIBOX_PASSWORD')), \
+                           use_ssl=True)
     elif path.isfile(path.expanduser('~') + '/.infinidat/infinisdk.ini'):
-        system = InfiniBox(box)
+        system = InfiniBox(box, use_ssl=True)
     else:
         module.fail_json(msg="You must set INFINIBOX_USER and INFINIBOX_PASSWORD environment variables or set username/password module arguments")
 


### PR DESCRIPTION
Add support for the thin_provision parameter to infini_fs.py. The default provisioning is THICK for backwards compatibility