### PR TITLE
fix: exclude infinidat from collection build to prevent recursive symlink in published artifact

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -50,3 +50,4 @@ build_ignore:
   - 'vault_password.txt'
   - 'tests/reproduce'
   - 'scripts'
+  - 'infinidat'


### PR DESCRIPTION
## Summary

- Adds `infinidat` to `build_ignore` in `galaxy.yml`

This resolves the root cause of the recursive symlink reported in
Infinidat/ansible-infinidat-collection#26 from occurring again in future releases.

Related to https://github.com/ansible-community/ansible-build-data/issues/720

## Background

Published releases of this collection (confirmed in 1.8.4) contain a recursive
symbolic link inside the installed content:

    ansible_collections/infinidat/infinibox/infinidat/infinibox -> ..

The symlink target (`..`) resolves back to the collection root, creating an
infinite loop:

    collection_root → collection_root/infinidat/infinibox → collection_root → ...

### How it gets into the tarball

The likely cause is a developer convenience symlink created manually in the local
working tree — `infinidat/infinibox -> ..` — so that Python can resolve
`infinidat.infinibox` imports from the repo root without the collection needing to
be installed. Because this path is not tracked in git it is invisible to code
review, but `ansible-galaxy collection build` walks the working directory and
picks it up. With no `infinidat` entry in `build_ignore`, the symlink is silently
included in the published tarball.

`ansible-galaxy collection build` records it as `ftype: "dir"` in `FILES.json`
(it follows the symlink to its resolved target) rather than as `ftype: "symlink"`,
so no warning is emitted at build time.

## Fix

Adding `infinidat` to `build_ignore` ensures the path is excluded at build time
regardless of whether the convenience symlink exists in a developer's working tree.

## Verification

The fix was verified locally by replicating the issue and confirming the build
excludes the path:

```bash
# Replicate the symlink
mkdir -p infinidat && ln -s .. infinidat/infinibox

# Build with the fix in place
ansible-galaxy collection build --force

# Confirm infinidat is absent from the tarball
tar -tzf infinidat-infinibox-1.8.4.tar.gz | grep infinidat
# (no output — infinidat is not present)
```