### PR TITLE
Exclude the local infinidat/ path from the built collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ _test-ubuntu:
 
 galaxy-collection-build: _test-venv  ## Build the collection. Use for local dev; publish enforces releasable separately.
 	@echo -e $(_begin)
-	rm -rf collections/
+	rm -rf collections/ infinidat/
 	ansible-galaxy collection build
 	@echo -e $(_finish)
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -44,6 +44,7 @@ build_ignore:
   - '.pytest_cache'
   - 'Makefile*'
   - 'collections'
+  - 'infinidat'
   - 'venv'
   - 'Session.vim'
   - 'ibox_vars/iboxCICD.yml'


### PR DESCRIPTION
The published infinidat.infinibox 1.8.4 artifact on Galaxy contains a stray symlink at its root:

    infinidat/infinibox -> ..

The symlink points at the collection's own top-level directory. Tools that dereference symlinks while copying the extracted collection descend into it, find the same symlink one level down, and repeat until they reach a path length limit. The ansible 14.3.0 sdist and wheel on PyPI were built from this artifact and grew to roughly 55 MB, with the collection nested inside itself about 40 levels deep and 3,034 duplicate files.

The repository does not track this symlink. `.gitignore` lists `infinidat/`, which suggests a developer created it locally so the working copy resolves at the `NAMESPACE/NAME` path that Ansible expects. `build_ignore` in galaxy.yml already excludes the comparable `collections` artifact, but not this one, so a build run in a working copy that still has the leftover packages it.

Add `infinidat` to `build_ignore` so any build excludes the path, and remove it alongside `collections/` in the galaxy-collection-build target.

Verified by rebuilding the collection with the leftover symlink in place. Before the change the artifact contains `infinidat/infinibox -> ..`. After it the artifact is clean. The check was run with an unpatched ansible-galaxy, so it does not depend on a fix landing in ansible-core.

Example of packaged ansible.
I am also opening an PR for ansible to include checks to avoid this in packaging

```
drwxr-xr-x root/root         0 2026-08-11 23:19 usr/lib/python3.14/site-packages/ansible_collections/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinida/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/meta/
-rw-r--r-- root/root       197 2026-08-11 23:19 usr/lib/python3.14/site-packages/ansible_collections/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinida/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/infinidat/infinibox/meta/execution-environment.yml
```


Assisted-by: Claude Code (Claude Sonnet 5)